### PR TITLE
Enable attachments for news

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
                 </nav>
             </div>
             <div id="ecoescuelas-link" class="hidden mb-4 p-4 bg-yellow-100 rounded-lg text-center">
-                <a href="https://example.com/ECOESCUELAS.pdf" target="_blank" class="text-green-800 font-bold underline">Documento ECOESCUELAS</a>
+                <a href="https://drive.google.com/file/d/1eQne65n4E2QqqGdHzE9xAJuUgYpQ-tWm/view?usp=sharing" target="_blank" class="text-green-800 font-bold underline">Documento ECOESCUELAS</a>
             </div>
 
             <!-- Available Courses View -->
@@ -301,6 +301,8 @@
                     <input type="hidden" id="news-id">
                     <input type="text" id="news-title" placeholder="Título de la Noticia" class="w-full px-4 py-2 border rounded-lg" required>
                     <textarea id="news-content" placeholder="Contenido de la noticia..." class="w-full px-4 py-2 border rounded-lg h-48" required></textarea>
+                    <input type="text" id="news-image-url" placeholder="URL de imagen (opcional)" class="w-full px-4 py-2 border rounded-lg">
+                    <textarea id="news-files" placeholder="Enlaces de archivos (uno por línea)" class="w-full px-4 py-2 border rounded-lg h-24"></textarea>
                     <div class="flex justify-end space-x-4 mt-6">
                         <button type="button" id="cancel-news-form" class="bg-gray-300 text-gray-800 font-bold py-2 px-6 rounded-lg">Cancelar</button>
                         <button type="submit" class="brand-bg-green text-white font-bold py-2 px-6 rounded-lg">Guardar Noticia</button>
@@ -596,14 +598,23 @@
                 newsListDiv.innerHTML = '';
                 snapshot.forEach(doc => {
                     const newsItem = { id: doc.id, ...doc.data() };
+                    let attachmentsHTML = '';
+                    if (newsItem.imageUrl) {
+                        attachmentsHTML += `<img src="${newsItem.imageUrl}" class="w-full mt-4 rounded-lg" />`;
+                    }
+                    if (newsItem.files && newsItem.files.length > 0) {
+                        const links = newsItem.files.map(link => `<a href="${link}" target="_blank" class="text-blue-600 hover:underline block">${link}</a>`).join('');
+                        attachmentsHTML += `<div class="mt-4 p-4 brand-bg-light-green rounded-lg"><h5 class="font-bold mb-2">Archivos Adjuntos</h5>${links}</div>`;
+                    }
                     const card = `
                         <div class="bg-white p-6 rounded-lg shadow">
                             <h4 class="text-2xl font-bold brand-green mb-2">${newsItem.title}</h4>
                              <p class="text-sm text-gray-500 mb-2">Publicado el ${new Date(newsItem.date).toLocaleDateString('es-AR', {timeZone: 'UTC'})}</p>
                             <p class="text-gray-700 whitespace-pre-wrap">${newsItem.content}</p>
+                            ${attachmentsHTML}
                         </div>
                     `;
-                newsListDiv.innerHTML += card;
+                    newsListDiv.innerHTML += card;
                 });
             });
 
@@ -1130,10 +1141,14 @@
                         document.getElementById('news-id').value = newsId;
                         document.getElementById('news-title').value = news.title;
                         document.getElementById('news-content').value = news.content;
+                        document.getElementById('news-image-url').value = news.imageUrl || '';
+                        document.getElementById('news-files').value = (news.files || []).join('\n');
                     }
                 });
             } else {
                 document.getElementById('news-id').value = '';
+                document.getElementById('news-image-url').value = '';
+                document.getElementById('news-files').value = '';
             }
             newsFormModal.style.display = 'flex';
         }
@@ -1144,6 +1159,8 @@
             const newsData = {
                 title: document.getElementById('news-title').value,
                 content: document.getElementById('news-content').value,
+                imageUrl: document.getElementById('news-image-url').value,
+                files: document.getElementById('news-files').value.split('\n').filter(l => l.trim() !== ''),
                 date: new Date().toISOString().split('T')[0]
             };
             try {


### PR DESCRIPTION
## Summary
- allow adding an image URL and file links when creating or editing news items
- render attached image and files in the news list
- update ECOESCUELAS document link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882b4c888748326ae382d0baa4fa85a