### PR TITLE
Refactor enrollment export to support multiple enrollments per user

### DIFF
--- a/index.html
+++ b/index.html
@@ -2133,7 +2133,7 @@ function cancelSlotAdmin(slotId) {
                         courseTitle,
                         currentStatus: userDoc.data().status || 'inscripto',
                         totalEnrollments: userEnrollmentsCache.get(uid).length,
-                        allEnrollments: userEnrollmentsCache.get(uid).join(' | ')
+                        enrollments: [...userEnrollmentsCache.get(uid)]
                     });
                 }
             }
@@ -2150,9 +2150,13 @@ function cancelSlotAdmin(slotId) {
                     return;
                 }
 
-                let spreadsheet = 'Nombre\tDNI\tEmail\tTeléfono\tDirección\tTiene huerta/compostera\tDirección huerta/compostera\tEvento actual\tEstado actual\tCantidad de inscripciones\tInscripciones realizadas\r\n';
+                const maxEnrollments = records.reduce((max, record) => Math.max(max, record.enrollments.length), 0);
+                const headers = ['Nombre', 'DNI', 'Email', 'Teléfono', 'Dirección', 'Tiene huerta/compostera', 'Dirección huerta/compostera', 'Evento actual', 'Estado actual', 'Cantidad de inscripciones'];
+                for (let i = 1; i <= maxEnrollments; i++) headers.push(`Inscripción ${i}`);
+
+                let spreadsheet = headers.join('\t') + '\r\n';
                 records.forEach((record) => {
-                    spreadsheet += [
+                    const row = [
                         record.name,
                         record.dni,
                         record.email,
@@ -2163,8 +2167,10 @@ function cancelSlotAdmin(slotId) {
                         record.courseTitle,
                         record.currentStatus,
                         record.totalEnrollments,
-                        record.allEnrollments,
-                    ].map(escapeSpreadsheetCell).join('\t') + '\r\n';
+                        ...record.enrollments,
+                    ];
+                    while (row.length < headers.length) row.push('');
+                    spreadsheet += row.map(escapeSpreadsheetCell).join('\t') + '\r\n';
                 });
 
                 const blob = new Blob([spreadsheet], { type: 'application/vnd.ms-excel;charset=utf-8;' });


### PR DESCRIPTION
## Summary
Refactored the spreadsheet export functionality to properly handle users with multiple course enrollments by expanding each enrollment into separate columns instead of concatenating them into a single cell.

## Key Changes
- Changed `allEnrollments` from a pipe-delimited string to an array (`enrollments`) in the user record structure
- Dynamically generate spreadsheet headers based on the maximum number of enrollments across all users
- Added individual columns for each enrollment (e.g., "Inscripción 1", "Inscripción 2", etc.)
- Refactored row construction to spread enrollment array items as separate columns
- Added padding logic to ensure all rows have consistent column count matching the header length

## Implementation Details
- The maximum enrollment count is calculated using `reduce()` to determine how many enrollment columns are needed
- Headers are built dynamically with base columns followed by numbered enrollment columns
- Each row is padded with empty strings to match the total header count, ensuring proper alignment in the exported spreadsheet
- The `escapeSpreadsheetCell` function is still applied to all cell values for proper formatting

https://claude.ai/code/session_01HCkrwtTAdyHmZ782GwHSNN