### PR TITLE
Exportar personas_inscriptos con detalle de turnos separado en columnas

### DIFF
--- a/index.html
+++ b/index.html
@@ -2133,7 +2133,7 @@ function cancelSlotAdmin(slotId) {
                         courseTitle,
                         currentStatus: userDoc.data().status || 'inscripto',
                         totalEnrollments: userEnrollmentsCache.get(uid).length,
-                        enrollments: [...userEnrollmentsCache.get(uid)]
+                        allEnrollments: userEnrollmentsCache.get(uid).join(' | ')
                     });
                 }
             }
@@ -2150,13 +2150,9 @@ function cancelSlotAdmin(slotId) {
                     return;
                 }
 
-                const maxEnrollments = records.reduce((max, record) => Math.max(max, record.enrollments.length), 0);
-                const headers = ['Nombre', 'DNI', 'Email', 'Teléfono', 'Dirección', 'Tiene huerta/compostera', 'Dirección huerta/compostera', 'Evento actual', 'Estado actual', 'Cantidad de inscripciones'];
-                for (let i = 1; i <= maxEnrollments; i++) headers.push(`Inscripción ${i}`);
-
-                let spreadsheet = headers.join('\t') + '\r\n';
+                let spreadsheet = 'Nombre\tDNI\tEmail\tTeléfono\tDirección\tTiene huerta/compostera\tDirección huerta/compostera\tEvento actual\tEstado actual\tCantidad de inscripciones\tInscripciones realizadas\r\n';
                 records.forEach((record) => {
-                    const row = [
+                    spreadsheet += [
                         record.name,
                         record.dni,
                         record.email,
@@ -2167,10 +2163,8 @@ function cancelSlotAdmin(slotId) {
                         record.courseTitle,
                         record.currentStatus,
                         record.totalEnrollments,
-                        ...record.enrollments,
-                    ];
-                    while (row.length < headers.length) row.push('');
-                    spreadsheet += row.map(escapeSpreadsheetCell).join('\t') + '\r\n';
+                        record.allEnrollments,
+                    ].map(escapeSpreadsheetCell).join('\t') + '\r\n';
                 });
 
                 const blob = new Blob([spreadsheet], { type: 'application/vnd.ms-excel;charset=utf-8;' });

--- a/index.html
+++ b/index.html
@@ -2144,34 +2144,97 @@ function cancelSlotAdmin(slotId) {
         async function exportAdminEnrollmentsToExcel() {
             loadingSpinner.style.display = 'flex';
             try {
-                const records = await collectAdminEnrollmentRecords();
-                if (!records.length) {
+                const peopleMap = {};
+                const ensurePerson = async (uid, fallbackName) => {
+                    if (!peopleMap[uid]) {
+                        let userData = null;
+                        try {
+                            const uSnap = await getDoc(doc(db, 'artifacts', appId, 'users', uid));
+                            if (uSnap.exists()) userData = uSnap.data();
+                        } catch (err) {
+                            console.error('No se pudo leer perfil de usuario:', err);
+                        }
+                        peopleMap[uid] = { userData, enrolledName: fallbackName || '', courses: [], turnos: [] };
+                    }
+                    return peopleMap[uid];
+                };
+
+                const coursesSnap = await getDocs(collection(db, 'artifacts', appId, 'public', 'data', 'courses'));
+                for (const courseDoc of coursesSnap.docs) {
+                    const courseData = courseDoc.data();
+                    const enrolledSnap = await getDocs(collection(db, 'artifacts', appId, 'public', 'data', 'courses', courseDoc.id, 'enrolledUsers'));
+                    for (const userDoc of enrolledSnap.docs) {
+                        const person = await ensurePerson(userDoc.id, userDoc.data().name);
+                        person.courses.push({ title: courseData.title, date: courseData.date, status: userDoc.data().status || 'inscripto' });
+                    }
+                }
+
+                const turnosSnap = await getDocs(collection(db, 'artifacts', appId, 'public', 'data', 'turnos'));
+                for (const turnoDoc of turnosSnap.docs) {
+                    const t = turnoDoc.data();
+                    if (t.reserved && t.reservation && t.reservation.userId) {
+                        const person = await ensurePerson(t.reservation.userId, t.reservation.nombre);
+                        person.turnos.push({ date: t.date, time: t.time, reservation: t.reservation });
+                    }
+                }
+
+                const people = Object.values(peopleMap);
+                if (!people.length) {
                     showModal('No hay inscriptos para exportar.');
                     return;
                 }
+                people.sort((a, b) => (((a.userData && a.userData.name) || a.enrolledName || '')).localeCompare(((b.userData && b.userData.name) || b.enrolledName || '')));
 
-                let spreadsheet = 'Nombre\tDNI\tEmail\tTeléfono\tDirección\tTiene huerta/compostera\tDirección huerta/compostera\tEvento actual\tEstado actual\tCantidad de inscripciones\tInscripciones realizadas\r\n';
-                records.forEach((record) => {
-                    spreadsheet += [
-                        record.name,
-                        record.dni,
-                        record.email,
-                        record.phone,
-                        record.address,
-                        record.hasHuerta,
-                        record.huertaAddress,
-                        record.courseTitle,
-                        record.currentStatus,
-                        record.totalEnrollments,
-                        record.allEnrollments,
-                    ].map(escapeSpreadsheetCell).join('\t') + '\r\n';
-                });
+                const maxTurnos = people.reduce((max, person) => Math.max(max, person.turnos.length), 0);
+                const turnoFields = ['Institución', 'Charla', 'Fecha', 'Hora', 'Tipo', 'Nivel', 'Grado', 'Referente', 'Teléfono', 'Email', 'Alumnos', 'Acompañantes', 'Asistentes', 'Observaciones'];
+                const headers = ['Nombre', 'DNI', 'Dirección', 'Teléfono', 'Email', 'Huerta/Compostera', 'Dir. Huerta', 'Eventos inscriptos', 'Detalle eventos', 'Turnos ECOescuelas'];
+                for (let i = 1; i <= maxTurnos; i++) turnoFields.forEach(field => headers.push(`Turno ${i} - ${field}`));
 
-                const blob = new Blob([spreadsheet], { type: 'application/vnd.ms-excel;charset=utf-8;' });
+                const esc = (v) => { const s = String(v == null ? '' : v); return s.includes(',') || s.includes('"') || s.includes('\n') ? '"' + s.replace(/"/g, '""') + '"' : s; };
+                const rows = [headers.map(esc).join(',')];
+                for (const person of people) {
+                    const u = person.userData;
+                    const row = [
+                        u ? u.name : person.enrolledName,
+                        u ? u.dni : '',
+                        u ? u.address : '',
+                        u ? u.phone : '',
+                        u ? u.email : '',
+                        u ? (u.hasHuerta ? 'Sí' : 'No') : '-',
+                        u && u.hasHuerta ? u.huertaAddress : '',
+                        person.courses.length,
+                        person.courses.map(c => `${c.title} (${c.date || 'S/F'}) [${c.status}]`).join(' | '),
+                        person.turnos.length,
+                    ];
+                    person.turnos.forEach(t => {
+                        const r = t.reservation;
+                        row.push(
+                            r.institucion || '',
+                            r.taller || '',
+                            t.date || '',
+                            t.time || '',
+                            r.tipo || '',
+                            r.nivel || '',
+                            r.grado || '',
+                            r.referente || '',
+                            r.telefono || '',
+                            r.contactoEmail || '',
+                            r.alumnos || '',
+                            r.acompanantes || '',
+                            r.asistentes || '',
+                            r.observaciones || ''
+                        );
+                    });
+                    while (row.length < headers.length) row.push('');
+                    rows.push(row.map(esc).join(','));
+                }
+
+                const bom = '\uFEFF';
+                const blob = new Blob([bom + rows.join('\r\n')], { type: 'text/csv;charset=utf-8;' });
                 const link = document.createElement('a');
                 link.href = URL.createObjectURL(blob);
                 const dateSuffix = new Date().toISOString().slice(0, 10);
-                link.setAttribute('download', `inscriptos_completo_${dateSuffix}.xls`);
+                link.setAttribute('download', `personas_inscriptos_${dateSuffix}.csv`);
                 document.body.appendChild(link);
                 link.click();
                 document.body.removeChild(link);


### PR DESCRIPTION
## Resumen

- **Revierte** el cambio del PR #26 (columnas "Inscripción 1, 2, …"), que modificaba el export equivocado.
- El botón **"Exportar a Excel"** del listado de inscriptos vuelve a generar el archivo **`personas_inscriptos_<fecha>.csv`** (una fila por persona, CSV UTF-8 con BOM compatible con Excel) en lugar de `inscriptos_completo_<fecha>.xls`.
- La columna **"Detalle turnos"** —que juntaba institución, charla, fecha, tipo, nivel, grado, referente, contacto y asistentes en una sola celda— ahora se separa en **columnas individuales por turno**: `Turno 1 - Institución`, `Turno 1 - Charla`, `Turno 1 - Fecha`, `Turno 1 - Hora`, `Turno 1 - Tipo`, `Turno 1 - Nivel`, `Turno 1 - Grado`, `Turno 1 - Referente`, `Turno 1 - Teléfono`, `Turno 1 - Email`, `Turno 1 - Alumnos`, `Turno 1 - Acompañantes`, `Turno 1 - Asistentes`, `Turno 1 - Observaciones` (y así para Turno 2, 3, … según la cantidad máxima de turnos de una misma persona).
- Las columnas de datos personales (Nombre, DNI, Dirección, Teléfono, Email, Huerta/Compostera, Dir. Huerta, Eventos inscriptos, Detalle eventos, Turnos ECOescuelas) se mantienen igual que en el archivo original.

## Contexto

El export `personas_inscriptos` provenía de la rama `claude/show-registration-data-VRllU` (PR #24), que se promovió a producción en marzo pero nunca se mergeó a master. Al mergearse los PR #25 y #26, producción volvió al código de master y ese export se perdió. Este PR recupera la recolección de datos por persona (eventos + turnos ECOescuelas, vinculados por `reservation.userId`) y aplica la mejora pedida de separar el detalle de turnos en columnas.

## Verificación

Lógica probada con los datos del archivo real exportado (incluido el caso de una persona con 3 turnos y observaciones con comas): todas las filas quedan con el mismo número de columnas y el CSV abre correctamente en Excel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCkrwtTAdyHmZ782GwHSNN

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCkrwtTAdyHmZ782GwHSNN)_